### PR TITLE
fix: delegation exploit

### DIFF
--- a/test/EthernautCTF/DelegationExploit.t.sol
+++ b/test/EthernautCTF/DelegationExploit.t.sol
@@ -23,7 +23,7 @@ contract DelegationExploit is Test {
     console.log('Current owner: %s', owner);
     assertEq(owner, deployer);
 
-    vm.startPrank(exploiter);
+    vm.startPrank(exploiter, true);
     // Call the `fallback` method using Delegate's `pwn` selector.
     // TODO: Understand why the exploit does not work?!
     // https://github.com/foundry-rs/foundry/issues/824


### PR DESCRIPTION
## Description

Fix `Delegation` exploit (EthernautCTF).

It requires an update of [forge-std](https://github.com/foundry-rs/forge-std) to support `vm.startPrank(address, bool)`.

Closes #24 
